### PR TITLE
Optimize the basic CSS for the docs

### DIFF
--- a/docs/css/base.css
+++ b/docs/css/base.css
@@ -1,15 +1,13 @@
-
 /*!
- * Bootstrap v3.3.2 (http://getbootstrap.com)
- * Copyright 2011-2015 Twitter, Inc.
+ * Bootstrap v3.3.7 (http://getbootstrap.com)
+ * Copyright 2011-2016 Twitter, Inc.
  * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
  */
-
-/*! normalize.css v3.0.2 | MIT License | git.io/normalize */
+/*! normalize.css v3.0.3 | MIT License | github.com/necolas/normalize.css */
 html {
-  gfont-family: sans-serif;
+  font-family: sans-serif;
   -webkit-text-size-adjust: 100%;
-      -ms-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
 }
 body {
   margin: 0;
@@ -36,6 +34,14 @@ video {
   display: inline-block;
   vertical-align: baseline;
 }
+audio:not([controls]) {
+  display: none;
+  height: 0;
+}
+[hidden],
+template {
+  display: none;
+}
 a {
   background-color: transparent;
 }
@@ -43,8 +49,134 @@ a:active,
 a:hover {
   outline: 0;
 }
+abbr[title] {
+  border-bottom: 1px dotted;
+}
 b,
 strong {
+  font-weight: bold;
+}
+dfn {
+  font-style: italic;
+}
+h1 {
+  margin: .67em 0;
+  font-size: 2em;
+}
+mark {
+  color: #000;
+  background: #ff0;
+}
+small {
+  font-size: 80%;
+}
+sub,
+sup {
+  position: relative;
+  font-size: 75%;
+  line-height: 0;
+  vertical-align: baseline;
+}
+sup {
+  top: -.5em;
+}
+sub {
+  bottom: -.25em;
+}
+img {
+  border: 0;
+}
+svg:not(:root) {
+  overflow: hidden;
+}
+figure {
+  margin: 1em 40px;
+}
+hr {
+  height: 0;
+  -webkit-box-sizing: content-box;
+  -moz-box-sizing: content-box;
+  box-sizing: content-box;
+}
+pre {
+  overflow: auto;
+}
+code,
+kbd,
+pre,
+samp {
+  font-family: monospace, monospace;
+  font-size: 1rem;
+}
+button,
+input,
+optgroup,
+select,
+textarea {
+  margin: 0;
+  font: inherit;
+  color: inherit;
+}
+button {
+  overflow: visible;
+}
+button,
+select {
+  text-transform: none;
+}
+button,
+html input[type="button"],
+input[type="reset"],
+input[type="submit"] {
+  -webkit-appearance: button;
+  cursor: pointer;
+}
+button[disabled],
+html input[disabled] {
+  cursor: default;
+}
+button::-moz-focus-inner,
+input::-moz-focus-inner {
+  padding: 0;
+  border: 0;
+}
+input {
+  line-height: normal;
+}
+input[type="checkbox"],
+input[type="radio"] {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+  padding: 0;
+}
+input[type="number"]::-webkit-inner-spin-button,
+input[type="number"]::-webkit-outer-spin-button {
+  height: auto;
+}
+input[type="search"] {
+  -webkit-box-sizing: content-box;
+  -moz-box-sizing: content-box;
+  box-sizing: content-box;
+  -webkit-appearance: textfield;
+}
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+fieldset {
+  padding: .35em .625em .75em;
+  margin: 0 2px;
+  border: 1px solid #c0c0c0;
+}
+legend {
+  padding: 0;
+  border: 0;
+}
+textarea {
+  overflow: auto;
+}
+optgroup {
   font-weight: bold;
 }
 table {
@@ -64,7 +196,7 @@ th {
     text-shadow: none !important;
     background: transparent !important;
     -webkit-box-shadow: none !important;
-            box-shadow: none !important;
+    box-shadow: none !important;
   }
   a,
   a:visited {
@@ -106,9 +238,6 @@ th {
   h3 {
     page-break-after: avoid;
   }
-  select {
-    background: #fff !important;
-  }
   .navbar {
     display: none;
   }
@@ -133,22 +262,23 @@ th {
 }
 * {
   -webkit-box-sizing: border-box;
-     -moz-box-sizing: border-box;
-          box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
 }
 *:before,
 *:after {
   -webkit-box-sizing: border-box;
-     -moz-box-sizing: border-box;
-          box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
 }
 html {
-  font-size: 10px;
+  font-size: 18px;
 
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }
 body {
-  font-size: 14px;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  font-size: 1rem;
   line-height: 1.42857143;
   color: #333;
   background-color: #fff;
@@ -161,6 +291,185 @@ textarea {
   font-size: inherit;
   line-height: inherit;
 }
+a {
+  color: #337ab7;
+  text-decoration: none;
+}
+a:hover,
+a:focus {
+  color: #23527c;
+  text-decoration: underline;
+}
+a:focus {
+  outline: 5px auto -webkit-focus-ring-color;
+  outline-offset: -2px;
+}
+figure {
+  margin: 0;
+}
+img {
+  vertical-align: middle;
+}
+hr {
+  margin-top: 20px;
+  margin-bottom: 20px;
+  border: 0;
+  border-top: 1px solid #eee;
+}
+[role="button"] {
+  cursor: pointer;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+.h1,
+.h2,
+.h3,
+.h4,
+.h5,
+.h6 {
+  font-family: inherit;
+  font-weight: 500;
+  line-height: 1.1;
+  color: inherit;
+}
+h1 small,
+h2 small,
+h3 small,
+h4 small,
+h5 small,
+h6 small,
+.h1 small,
+.h2 small,
+.h3 small,
+.h4 small,
+.h5 small,
+.h6 small,
+h1 .small,
+h2 .small,
+h3 .small,
+h4 .small,
+h5 .small,
+h6 .small,
+.h1 .small,
+.h2 .small,
+.h3 .small,
+.h4 .small,
+.h5 .small,
+.h6 .small {
+  font-weight: normal;
+  line-height: 1;
+  color: #777;
+}
+h1,
+.h1,
+h2,
+.h2,
+h3,
+.h3 {
+  margin-top: 20px;
+  margin-bottom: 10px;
+}
+h1 small,
+.h1 small,
+h2 small,
+.h2 small,
+h3 small,
+.h3 small,
+h1 .small,
+.h1 .small,
+h2 .small,
+.h2 .small,
+h3 .small,
+.h3 .small {
+  font-size: 65%;
+}
+h4,
+.h4,
+h5,
+.h5,
+h6,
+.h6 {
+  margin-top: 10px;
+  margin-bottom: 10px;
+}
+h4 small,
+.h4 small,
+h5 small,
+.h5 small,
+h6 small,
+.h6 small,
+h4 .small,
+.h4 .small,
+h5 .small,
+.h5 .small,
+h6 .small,
+.h6 .small {
+  font-size: 75%;
+}
+h1,
+.h1 {
+  font-size: 36px;
+}
+h2,
+.h2 {
+  font-size: 30px;
+}
+h3,
+.h3 {
+  font-size: 24px;
+}
+h4,
+.h4 {
+  font-size: 18px;
+}
+h5,
+.h5 {
+  font-size: 14px;
+}
+h6,
+.h6 {
+  font-size: 12px;
+}
+
+p {
+  margin: 0 0 10px;
+}
+small,
+.small {
+  font-size: 85%;
+}
+
+ul,
+ol {
+  margin-top: 0;
+  margin-bottom: 10px;
+}
+ul ul,
+ol ul,
+ul ol,
+ol ol {
+  margin-bottom: 0;
+}
+
+code,
+kbd,
+pre,
+samp {
+  font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
+}
+code {
+  padding: 2px 4px;
+  font-size: 90%;
+  color: #c7254e;
+  background-color: #f9f2f4;
+  border-radius: 4px;
+}
+
 .container {
   padding-right: 15px;
   padding-left: 15px;
@@ -828,6 +1137,7 @@ textarea {
     margin-left: 0;
   }
 }
+
 .clearfix:before,
 .clearfix:after,
 .dl-horizontal dd:before,
@@ -856,6 +1166,8 @@ textarea {
 .pager:after,
 .panel-body:before,
 .panel-body:after,
+.modal-header:before,
+.modal-header:after,
 .modal-footer:before,
 .modal-footer:after {
   display: table;
@@ -875,15 +1187,16 @@ textarea {
 .navbar-collapse:after,
 .pager:after,
 .panel-body:after,
+.modal-header:after,
 .modal-footer:after {
   clear: both;
 }
-
-/* ------------ */
+/*
+ * ======================================
+ * Customizations
+ */
 body {
     gbackground-color: #ccc;
-    font-family: Georgia, serif;
-    font-size: 14pt;
     line-height: 140%;
     gbackground-image: -webkit-linear-gradient(top, #AAF, #DDF 1000px);
 }
@@ -981,7 +1294,6 @@ pre.prettyprint li {
     body {
         background-image: none;
         background-color: white;
-        font-size: 12pt;
     }
     pre.prettyprint {
         width: 100%;
@@ -989,13 +1301,3 @@ pre.prettyprint li {
         overflow-x: scroll;
     }
 }
-
-
-/*
- * cribbed from boostrap
- * Bootstrap v3.3.2 (http://getbootstrap.com)
- * Copyright 2011-2015 Twitter, Inc.
- * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
- */
-
-

--- a/docs/css/index.css
+++ b/docs/css/index.css
@@ -1,4 +1,3 @@
 .hide {
     display: inline !important;
 }
-

--- a/docs/css/lesson.css
+++ b/docs/css/lesson.css
@@ -26,7 +26,7 @@ img.lesson {
   gbackground-color: #ffe;
 }
 .lesson-sidebar {
-  font-size: small;
+  font-size: .9rem;
   gbackground-color: #eff;
 }
 .lesson-sidebar>ul>li {
@@ -44,16 +44,9 @@ img.lesson {
     gbackground-color: green;
 }
 h1, h2, h3, h4 {
-  font-family: sans-serif;
   line-height: 1em;
 }
-h3 {
-  font-size: medium;
-}
-code {
-    color: black;
-    font-family: monospace;
-}
+
 blockquote {
   background-color: #C8E8FF;
   padding: 1em;
@@ -111,7 +104,7 @@ table.vertex_table {
   border: 1px solid black;
   border-collapse: collapse;
   font-family: monospace;
-  font-size: small;
+  font-size: .9rem;
 }
 
 table.vertex_table th {
@@ -150,7 +143,6 @@ div.webgl_bottombar {
 }
 div.webgl_bottombar>h3 {
   gbackground-color: red;
-  font-size: x-large;
   font-weight: bold;
   margin-bottom: 1em;
 }
@@ -177,79 +169,108 @@ code {
 }
 
 /* --- Prettify --- */
-pre.prettyprint .nocode { background-color: none; color: #000 }
-pre.prettyprint .str { color: #080 } /* string          */
-pre.prettyprint .kwd { color: #008 } /* keyword         */
-pre.prettyprint .com { color: #800 } /* comment         */
-pre.prettyprint .typ { color: #606 } /* type            */
-pre.prettyprint .lit { color: #066 } /* literal         */
-pre.prettyprint .pun { color: #660 } /* punctuation     */
-pre.prettyprint .pln { color: #000 } /* plaintext       */
-pre.prettyprint .tag { color: #008 } /* html/xml tag    */
-pre.prettyprint .atn { color: #606 } /* attribute name  */
-pre.prettyprint .atv { color: #080 } /* attribute value */
-pre.prettyprint .dec { color: #606 } /* decimal         */
-pre.prettyprint .var { color: #606 } /* variable name   */
-pre.prettyprint .fun { color: #F00 } /* function name   */
-
-pre.prettyprint ul.modifiedlines {
-    list-style-type: none;
-    padding-left: 0;
-}
-pre.prettyprint ul.modifiedlines li.linemodified {
-    list-style-type: none;
-    background-color: #A1EAF6;
-}
-pre.prettyprint ul.modifiedlines li.linedeleted {
-    list-style-type: none;
-    background-color: #F0B9B9;
-    text-decoration: line-through;
+/* desert scheme ported from vim to google prettify */
+pre.prettyprint {
+    display: block;
+    font-size: .9rem;
+    font-family: Menlo, "Bitstream Vera Sans Mono", "DejaVu Sans Mono", Monaco, Consolas, monospace;
+    background-color: #f5f5f5;
+    padding: 10px;
 }
 
-pre.prettyprint ul.modifiedlines li.lineadded {
-    list-style-type: none;
-    background-color: #A2EDC9;
+pre ol,
+pre ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
 }
 
-
-pre.prettyprint, code.prettyprint {
-    color: #000;
-    background: #eee;
-    border: 1px solid #000;
-    box-shadow: 3px 3px 10px #ccc;
-    font-size: 8pt;
-    font-family: "Lucida Console", Monaco, monospace;
-    width: 95%;
-    margin: auto;
-    padding: 1em;
-    text-align: left;           /* override justify on body */
-    overflow: auto;             /* allow scroll bar in case of long lines - goes together with white-space: nowrap! */
-    white-space: pre;        /* was nowrap, prevent line wrapping */
-    line-height: 10pt;
-}
-@media print{
-    pre.prettyprint .str, code.prettyprint .str{color:#060}
-    pre.prettyprint .kwd, code.prettyprint .kwd{color:#006;font-weight:bold}
-    pre.prettyprint .com, code.prettyprint .com{color:#600;font-style:italic}
-    pre.prettyprint .typ, code.prettyprint .typ{color:#404;font-weight:bold}
-    pre.prettyprint .lit, code.prettyprint .lit{color:#044}
-    pre.prettyprint .pun, code.prettyprint .pun{color:#440}
-    pre.prettyprint .pln, code.prettyprint .pln{color:#000}
-    pre.prettyprint .tag, code.prettyprint .tag{color:#006;font-weight:bold}
-    pre.prettyprint .atn, code.prettyprint .atn{color:#404}
-    pre.prettyprint .atv, code.prettyprint .atv{color:#060}
-pre.prettyprint, code.prettyprint {
-    color: #000;
-    background: #EEE;
-    font-size: 8pt;
-    font-family: "Lucida Console", Monaco, monospace;
-    width: 95%;
-    margin: auto;
-    padding: 6px 3px 13px 3px;  /* padding-bottom solves hor. scrollbar hiding single line of code in IE6 but causes vert. scrollbar... */
-    text-align: left;           /* override justify on body */
-    goverflow: auto;             /* allow scroll bar in case of long lines - goes together with white-space: nowrap! */
-    white-space: pre;        /* was nowrap, prevent line wrapping */
-    line-height: 10pt;
-}
+pre .nocode {
+    background-color: transparent;
+    color: #000
 }
 
+pre .str {
+    color: #718c00;
+}
+
+pre .kwd {
+    color: #8959a8;
+}
+
+pre .com {
+    color: #8e908c;
+}
+
+pre .typ {
+    color: #4271ae;
+}
+
+pre .lit {
+    color: #f5871f;
+}
+
+pre .pun {
+    color: #4d4d4c;
+}
+
+pre .opn {
+    color: #4d4d4c;
+}
+
+pre .clo {
+    color: #4d4d4c;
+}
+
+pre .tag {
+    color: #c82829;
+}
+
+pre .atn {
+    color: #f5871f;
+}
+
+pre .atv {
+    color: #3e999f;
+}
+
+pre .dec {
+    color: #f5871f;
+}
+
+pre .var {
+    color: #c82829;
+}
+
+pre .fun {
+    color: #4271ae;
+}
+
+ol.linenums {
+    margin-top: 0;
+    margin-bottom: 0;
+    color: #AEAEAE
+}
+
+/* IE indents via margin-left */
+li.L0, li.L1, li.L2, li.L3, li.L5, li.L6, li.L7, li.L8 {
+    list-style-type: none
+}
+
+/* Alternate shading for lines */
+li.L1, li.L3, li.L5, li.L7, li.L9 {
+}
+
+@media print {
+    pre.prettyprint { background-color: transparent }
+    pre .str, code .str { color: #060 }
+    pre .kwd, code .kwd { color: #006; font-weight: bold }
+    pre .com, code .com { color: #600; font-style: italic }
+    pre .typ, code .typ { color: #404; font-weight: bold }
+    pre .lit, code .lit { color: #044 }
+    pre .pun, code .pun { color: #440 }
+    pre .pln, code .pln { color: #000 }
+    pre .tag, code .tag { color: #006; font-weight: bold }
+    pre .atn, code .atn { color: #404 }
+    pre .atv, code .atv { color: #060 }
+}


### PR DESCRIPTION
I really like the project and wanted to help even if I'm not able to contribute to the server architecture. As I noticed that the docs look a little bit "outdated" I decided to take a closer look at it.
This pull requests optimized the CSS styles for the docs. I will open another pull request later where I corrected some spelling and other smaller problems.

* Updates Bootstrap styles to the latest version
* Increases the base font size to 18px (See [this article](https://blog.attackthefront.io/your-body-text-is-too-small-5e02d36dc902))
* Unifies the fonts across all docs
* Switches to a modern theme for Code Prettify

Here are two example screenshots:

![Screen 1](https://share.kovah.de/f/hX9SFFJcRf.png)

--

![Screen 2](https://share.kovah.de/f/eKqSR7Uvom.png)